### PR TITLE
Add FastAPI frontend with Bootstrap and Leaflet

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app.main:app --host 0.0.0.0 --port $PORT

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+
+# Mount static directory for CSS and JavaScript
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+# Jinja2 templates directory
+templates = Jinja2Templates(directory="templates")
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    """Render the homepage with map"""
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,5 @@
-# ─── Streamlit core & helpers ────────────────────
-streamlit>=1.35.0,<2        # must be ≥1.35 for st-folium 0.25+
-streamlit-option-menu==0.3.6
-streamlit-folium>=0.25.0    # latest build, requires streamlit≥1.35
-streamlit-aggrid==0.3.4.post3  # PyPI build with checkbox support
-
-# ─── Mapping stack ───────────────────────────────
-folium>=0.16.0
-simplekml==1.3.6
-
-# ─── Geo stack (wheels for Py 3.12) ──────────────
-geopandas==0.14.4
-fiona>=1.10.1
-shapely>=2.1.0
-pyproj>=3.6.1
-
-# ─── Utilities ──────────────────────────────────
-PyYAML>=6.0
-requests>=2.31.0
+fastapi
+uvicorn
+jinja2
 pyshp==2.3.1
 pytest

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,5 @@
+/* Custom page styles */
+#map {
+    height: 500px;
+    width: 100%;
+}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,0 +1,5 @@
+// Initialize a simple Leaflet map
+var map = L.map('map').setView([-23.5, 143.0], 5);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Parcel Viewer</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4">Parcel Viewer</h1>
+    <div id="map"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="{{ url_for('static', path='js/map.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a new FastAPI application
- serve Jinja2 templates and static files
- add Bootstrap/Leaflet styled index page
- add Procfile for Render deployment
- slim requirements to FastAPI/Jinja2/Uvicorn/pyshp

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a25fdd33c8327b5e8852ccc96eb38