### PR TITLE
Rewrite frontend layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,28 +1,17 @@
 import { useState } from 'react';
 import { GeoJSON } from 'react-leaflet';
 import ParcelMap from './ParcelMap.jsx';
+import SearchPanel from './SearchPanel.jsx';
+import { API_BASE } from './api.js';
 import './App.css';
 
-// Back-end base URL can be injected at build time via VITE_API_BASE.
-// If not provided, default to the current origin.
-const API_BASE = import.meta.env.VITE_API_BASE || '';
-
 function App() {
-  const [bulk, setBulk] = useState('');
   const [features, setFeatures] = useState([]);
   const [selected, setSelected] = useState({});
 
-  const handleSearch = async () => {
-    const resp = await fetch(`${API_BASE}/api/search`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ inputs: bulk.split('\n') })
-    });
-    if (resp.ok) {
-      const data = await resp.json();
-      setFeatures(data.features || []);
-      setSelected({});
-    }
+  const handleResults = (list) => {
+    setFeatures(list);
+    setSelected({});
   };
 
   const toggle = (idx) => {
@@ -49,25 +38,13 @@ function App() {
 
   return (
     <div className="app">
-      <div className="sidebar">
-        <h2>Search Parcels</h2>
-        <textarea value={bulk} onChange={(e) => setBulk(e.target.value)} placeholder="Lot/Plan each line" />
-        <button onClick={handleSearch}>Search</button>
-        <div className="results">
-          {features.map((f, i) => (
-            <label key={i}>
-              <input type="checkbox" checked={!!selected[i]} onChange={() => toggle(i)} />
-              {f.properties.lot || f.properties.lotnumber} {f.properties.plan || f.properties.planlabel}
-            </label>
-          ))}
-        </div>
-        {features.length > 0 && (
-          <div className="downloads">
-            <button onClick={() => download('kml')}>Download KML</button>
-            <button onClick={() => download('shp')}>Download SHP</button>
-          </div>
-        )}
-      </div>
+      <SearchPanel
+        onResults={handleResults}
+        features={features}
+        selected={selected}
+        toggle={toggle}
+        download={download}
+      />
       <ParcelMap>
         {features.length > 0 && (
           <GeoJSON data={{ type: 'FeatureCollection', features }} />

--- a/frontend/src/ResultsList.jsx
+++ b/frontend/src/ResultsList.jsx
@@ -1,0 +1,17 @@
+export default function ResultsList({ features, selected, toggle }) {
+  return (
+    <div className="results">
+      {features.map((f, i) => (
+        <label key={i}>
+          <input
+            type="checkbox"
+            checked={!!selected[i]}
+            onChange={() => toggle(i)}
+          />
+          {f.properties.lot || f.properties.lotnumber}{' '}
+          {f.properties.plan || f.properties.planlabel}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/SearchPanel.jsx
+++ b/frontend/src/SearchPanel.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import ResultsList from './ResultsList.jsx';
+import { API_BASE } from './api.js';
+
+export default function SearchPanel({ onResults, features, selected, toggle, download }) {
+  const [bulk, setBulk] = useState('');
+
+  const handleSearch = async () => {
+    const resp = await fetch(`${API_BASE}/api/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ inputs: bulk.split('\n') })
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      onResults(data.features || []);
+    }
+  };
+
+  return (
+    <div className="sidebar">
+      <h2>Search Parcels</h2>
+      <textarea
+        value={bulk}
+        onChange={(e) => setBulk(e.target.value)}
+        placeholder="Lot/Plan each line"
+      />
+      <button onClick={handleSearch}>Search</button>
+      <ResultsList features={features} selected={selected} toggle={toggle} />
+      {features.length > 0 && (
+        <div className="downloads">
+          <button onClick={() => download('kml')}>Download KML</button>
+          <button onClick={() => download('shp')}>Download SHP</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || '';


### PR DESCRIPTION
## Summary
- modularize frontend with `SearchPanel` and `ResultsList`
- keep map display but delegate searching logic to new components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c262d47bc8327be1ae618f36f318c