### PR TITLE
Fix PostCSS config ESM compatibility

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     '@tailwindcss/postcss': {},
     autoprefixer: {},


### PR DESCRIPTION
### **User description**
## Summary
- rename `postcss.config.cjs` to `postcss.config.js` and use `export default`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e0d14c2c483279548070e665f352a


___

### **PR Type**
Enhancement


___

### **Description**
- Convert PostCSS config from CommonJS to ES modules

- Replace `module.exports` with `export default` syntax


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CommonJS module.exports"] --> B["ES module export default"]
  B --> C["ESM compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postcss.config.js</strong><dd><code>Convert to ES module syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/postcss.config.js

<ul><li>Replace <code>module.exports</code> with <code>export default</code><br> <li> Convert CommonJS syntax to ES module format</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/Vision/pull/33/files#diff-4d9caaa225a07b88ab65596bbc1fc5022ef987038d0747f31f4678bb3b68bfed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

