### PR TITLE
Use MapLibre in legacy page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "maplibre-gl": "^3.6.1",
-    "@maplibre/maplibre-gl": "^1.0.0",
+    "maplibre-gl": "^5.6.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
-    "maplibre-gl": "^5.6.1",
     "@tailwindcss/postcss": "^0.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,5 +1,8 @@
-// Initialize a simple Leaflet map
-var map = L.map('map').setView([-23.5, 143.0], 5);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; OpenStreetMap contributors'
-}).addTo(map);
+import maplibregl from 'maplibre-gl';
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: 'https://demotiles.maplibre.org/style.json',
+  center: [143.0, -23.5],
+  zoom: 5,
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Parcel Viewer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.css" />
     <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
 </head>
 <body class="bg-dark text-white">
@@ -14,7 +14,7 @@
     <div id="map"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="{{ url_for('static', path='js/map.js') }}"></script>
+<script type="module" src="https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.js"></script>
+<script type="module" src="{{ url_for('static', path='js/map.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove leftover @maplibre/maplibre-gl dependency
- replace Leaflet page with MapLibre

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880026bf1b08327a85a0d80f1092e8e