### PR TITLE
Implement search drawer

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,76 +1,66 @@
 import { useState } from 'react';
-import MapView from './MapView';
-import Sidebar from './Sidebar';
+import Map from '../Map.jsx';
+import SearchPanel from '../SearchPanel.jsx';
+import Sidebar from './Sidebar.jsx';
 import { API_BASE } from '../api';
 
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [bulk, setBulk] = useState('');
-  const [results, setResults] = useState([]);
-  const [error, setError] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [features, setFeatures] = useState([]);
+  const [selected, setSelected] = useState({});
+  const [style, setStyle] = useState({
+    fill: '#ff0000',
+    outline: '#000000',
+    opacity: 0.5,
+    weight: 2,
+  });
 
   const toggleSidebar = () => setSidebarOpen((o) => !o);
 
-  const handleSearch = async () => {
-    const lines = bulk
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (!lines.length) return;
-    setError('');
-    try {
-      const r = await fetch(`${API_BASE}/api/search`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ inputs: lines }),
-      });
-      if (!r.ok) throw new Error('Search failed');
-      const data = await r.json();
-      setResults(data.features || []);
-    } catch (err) {
-      console.error(err);
-      setError('Failed to fetch results');
-    }
+  const handleResults = (list) => {
+    setFeatures(list);
+    setSelected({});
   };
 
-  const handleDownload = async () => {
-    if (!results.length) return;
-    setError('');
-    try {
-      const r = await fetch(`${API_BASE}/api/download/kml`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ features: results }),
-      });
-      if (!r.ok) throw new Error('Download failed');
-      const blob = await r.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'parcels.kml';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
-    } catch (err) {
-      console.error(err);
-      setError('Failed to download KML');
-    }
+  const toggleSelected = (idx) => {
+    setSelected((s) => ({ ...s, [idx]: !s[idx] }));
+  };
+
+  const download = async (type, folderName, fileName) => {
+    const sel = features.filter((_, i) => selected[i]);
+    const body = {
+      features: sel.length ? sel : features,
+      folderName,
+      fileName,
+    };
+    const r = await fetch(`${API_BASE}/api/download/${type}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) return;
+    const blob = await r.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
   };
 
   return (
     <div className="flex h-screen w-full overflow-hidden">
-      {/* Sidebar */}
       <Sidebar
         open={sidebarOpen}
-        handleSearch={handleSearch}
-        handleDownload={handleDownload}
-        resetMap={() => setResults([])}
+        openSearch={() => setSearchOpen(true)}
+        download={() => download('kml', 'Parcels', 'parcels.kml')}
+        resetMap={() => setFeatures([])}
       />
 
-      {/* Main area */}
-      <div className="flex flex-col flex-1 p-4 sm:ml-64">
-        {/* Navbar */}
+      <div className="flex flex-col flex-1 p-4 sm:ml-64 relative">
         <nav className="h-12 bg-gray-800 text-white flex items-center px-4 justify-between">
           <div className="flex items-center space-x-2">
             <button
@@ -95,64 +85,25 @@ export default function Layout() {
           <div></div>
         </nav>
 
-        <div className="flex flex-col md:flex-row flex-1 overflow-hidden p-4 border-2 border-gray-200 border-dashed rounded-lg dark:border-gray-700">
-          {/* Search and results */}
-          <div className="md:w-80 p-4 space-y-4 overflow-y-auto bg-white dark:bg-gray-900">
-            <textarea
-              className="w-full h-24 p-2 border border-gray-300 rounded-lg text-sm dark:bg-gray-700 dark:text-white"
-              value={bulk}
-              onChange={(e) => setBulk(e.target.value)}
-              placeholder={'QLD 3RP123456\nNSW 4/DP765432'}
-            />
-            <button
-              className="w-full text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-4 py-2"
-              onClick={handleSearch}
-            >
-              Search
-            </button>
-            {error && <div className="text-red-600 text-sm">{error}</div>}
-            {results.length > 0 && (
-              <div className="space-y-2">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400">
-                    <tr>
-                      <th scope="col" className="px-2 py-1">
-                        Lot
-                      </th>
-                      <th scope="col" className="px-2 py-1">
-                        Plan
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {results.map((f, i) => {
-                      const p = f.properties || {};
-                      return (
-                        <tr key={i} className="border-b dark:border-gray-700">
-                          <td className="px-2 py-1">{p.lot ?? p.lotnumber ?? ''}</td>
-                          <td className="px-2 py-1">{p.plan ?? p.planlabel ?? ''}</td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-                <button
-                  className="w-full text-white bg-green-600 hover:bg-green-700 font-medium rounded-lg text-sm px-4 py-2"
-                  onClick={handleDownload}
-                >
-                  Download KML
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* Map */}
-          <div className="flex-1 overflow-hidden">
-            <MapView />
-          </div>
+        <div className="flex-1 overflow-hidden">
+          <Map features={features} style={style} onFeatureClick={toggleSelected} />
         </div>
+      </div>
+
+      <div
+        className={`fixed top-0 right-0 z-50 transform transition-transform duration-300 ${searchOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <SearchPanel
+          onResults={handleResults}
+          features={features}
+          selected={selected}
+          toggle={toggleSelected}
+          download={download}
+          style={style}
+          setStyle={setStyle}
+          onClose={() => setSearchOpen(false)}
+        />
       </div>
     </div>
   );
 }
-

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import logo from '../assets/logo.svg?url';
 
-export default function Sidebar({ open, handleSearch, handleDownload, resetMap }) {
+export default function Sidebar({ open, openSearch, download, resetMap }) {
   return (
     <aside
       id="logo-sidebar"
@@ -15,7 +15,7 @@ export default function Sidebar({ open, handleSearch, handleDownload, resetMap }
         <ul className="space-y-2 font-medium">
           <li>
             <button
-              onClick={handleSearch}
+              onClick={openSearch}
               className="flex items-center w-full p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
             >
               <svg
@@ -33,7 +33,7 @@ export default function Sidebar({ open, handleSearch, handleDownload, resetMap }
           </li>
           <li>
             <button
-              onClick={handleDownload}
+              onClick={download}
               className="flex items-center w-full p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
             >
               <svg


### PR DESCRIPTION
## Summary
- add SearchPanel as a sliding drawer
- hook SearchPanel into sidebar
- keep map visible while search panel overlays it

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688084d5c224832793f04afb10d5e22d