### PR TITLE
Fix layout rendering

### DIFF
--- a/frontend/src/Map.jsx
+++ b/frontend/src/Map.jsx
@@ -97,7 +97,9 @@ export default function Map({ features, style, onFeatureClick }) {
     map.setPaintProperty('parcels-line', 'line-width', style.weight);
   }, [style]);
 
-  return <div ref={containerRef} className="maplibre-container flex-1" />;
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+  );
 }
 
 function computeBbox(features) {

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -60,49 +60,34 @@ export default function Layout() {
         resetMap={() => setFeatures([])}
       />
 
-      <div className="flex flex-col flex-1 p-4 sm:ml-64 relative">
+      <div className="flex flex-col flex-1">
         <nav className="h-12 bg-gray-800 text-white flex items-center px-4 justify-between">
-          <div className="flex items-center space-x-2">
-            <button
-              type="button"
-              className="inline-flex items-center p-2 mt-2 ms-3 text-sm text-gray-500 rounded-lg sm:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600"
-              onClick={toggleSidebar}
-              aria-controls="logo-sidebar"
-            >
-              <span className="sr-only">Open sidebar</span>
-              <svg
-                className="w-6 h-6"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
-              >
-                <path d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z" />
-              </svg>
-            </button>
-            <span className="font-semibold">Vision</span>
-          </div>
-          <div></div>
+          <button
+            type="button"
+            className="inline-flex items-center p-2 text-sm text-gray-500 rounded-lg sm:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200"
+            onClick={toggleSidebar}
+            aria-controls="logo-sidebar"
+          >
+            <span className="sr-only">Open sidebar</span>
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+              <path d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z" />
+            </svg>
+          </button>
+          <span className="font-semibold">Vision</span>
         </nav>
-
-        <div className="flex-1 overflow-hidden">
+        <main className="flex-1 flex">
+          <SearchPanel
+            onResults={handleResults}
+            features={features}
+            selected={selected}
+            toggle={toggleSelected}
+            download={download}
+            style={style}
+            setStyle={setStyle}
+            onClose={() => setSearchOpen(false)}
+          />
           <Map features={features} style={style} onFeatureClick={toggleSelected} />
-        </div>
-      </div>
-
-      <div
-        className={`fixed top-0 right-0 z-50 transform transition-transform duration-300 ${searchOpen ? 'translate-x-0' : 'translate-x-full'}`}
-      >
-        <SearchPanel
-          onResults={handleResults}
-          features={features}
-          selected={selected}
-          toggle={toggleSelected}
-          download={download}
-          style={style}
-          setStyle={setStyle}
-          onClose={() => setSearchOpen(false)}
-        />
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
### **User description**
## Summary
- adjust Map return container
- clean Layout JSX to show sidebar, topbar, search panel and map
- ensure App renders Layout

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run dev`

------
https://chatgpt.com/codex/tasks/task_e_68808f36c734832796e8ed506dff941f


___

### **PR Type**
Bug fix


___

### **Description**
- Fix blank screen by restoring Map container styling

- Simplify Layout component structure and navigation

- Reposition SearchPanel from fixed overlay to main content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Layout Component"] --> B["Navigation Bar"]
  A --> C["Main Content Area"]
  C --> D["SearchPanel"]
  C --> E["Map Component"]
  E --> F["Container with 100% dimensions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Map.jsx</strong><dd><code>Restore Map container dimensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/Map.jsx

<ul><li>Replace flex-1 className with inline styles<br> <li> Set container to 100% width and height<br> <li> Remove maplibre-container class</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/Vision/pull/49/files#diff-ad63a94f7045e4390d6d8a788af8f95e28d91f73947eef71fe2488e44a64cd16">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Layout.jsx</strong><dd><code>Simplify Layout structure and reposition SearchPanel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/Layout.jsx

<ul><li>Remove padding and margin classes from main container<br> <li> Simplify navigation bar structure and remove empty div<br> <li> Move SearchPanel from fixed overlay to main flex container<br> <li> Replace div with semantic main element</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/Vision/pull/49/files#diff-708cc0ca6d94dd55455370ec8c75df43b784155947ba128726372d9f12a87430">+25/-40</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

